### PR TITLE
Need to nudge the version up for Puppet 6 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">3.0.0 <6.0.0"
+      "version_requirement": ">3.0.0 <7.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This module hasn't been updated in a LONG time and doesn't appear supported by the author anymore. Despite this it does still work okay on my Puppet 6 stack. 

I believe we should be able to continue with it and maintain it internally as required. As such we should be okay to update the version requirement for Puppet to >3.0.0 < 7.0.0.